### PR TITLE
Fix: Add missing test

### DIFF
--- a/test/Unit/ConstructTest.php
+++ b/test/Unit/ConstructTest.php
@@ -39,6 +39,15 @@ final class ConstructTest extends Framework\TestCase
         $this->assertCount(0, $construct->fileNames());
     }
 
+    public function testToStringReturnsName()
+    {
+        $name = $this->faker()->word;
+
+        $construct = Construct::fromName($name);
+
+        $this->assertSame($name, $construct->__toString());
+    }
+
     public function testDefinedInClonesInstanceAndAddsFileNames()
     {
         $faker = $this->faker();


### PR DESCRIPTION
This PR

* [x] asserts that `Construct::__toString()` returns the name of the construct

Follows #1.