### PR TITLE
Fix: Typo

### DIFF
--- a/test/Unit/ConstructsTest.php
+++ b/test/Unit/ConstructsTest.php
@@ -46,7 +46,7 @@ final class ConstructsTest extends Framework\TestCase
         }
     }
 
-    public function testFromDirectoryTHrowsDirectoryDoesNotExistIfDirectoryDoesNotExist()
+    public function testFromDirectoryThrowsDirectoryDoesNotExistIfDirectoryDoesNotExist()
     {
         $directory = __DIR__ . '/NonExistent';
 


### PR DESCRIPTION
This PR

* [x] fixes a typo in a test method name