### PR TITLE
Enhancement: Handle parse errors

### DIFF
--- a/src/Constructs.php
+++ b/src/Constructs.php
@@ -20,16 +20,22 @@ final class Constructs
      *
      * @param string $source
      *
+     * @throws Exception\ParseError
+     *
      * @return Construct[]
      */
     public static function fromSource(string $source): array
     {
         $constructs = [];
 
-        $sequence = \token_get_all(
-            $source,
-            TOKEN_PARSE
-        );
+        try {
+            $sequence = \token_get_all(
+                $source,
+                TOKEN_PARSE
+            );
+        } catch (\ParseError $exception) {
+            throw Exception\ParseError::fromParseError($exception);
+        }
 
         $count = \count($sequence);
         $namespacePrefix = '';
@@ -129,7 +135,14 @@ final class Constructs
 
             $fileName = $fileInfo->getRealPath();
 
-            $constructsFromFile = self::fromSource(\file_get_contents($fileName));
+            try {
+                $constructsFromFile = self::fromSource(\file_get_contents($fileName));
+            } catch (Exception\ParseError $exception) {
+                throw Exception\ParseError::fromFileNameAndParseError(
+                    $fileName,
+                    $exception
+                );
+            }
 
             if (0 === \count($constructsFromFile)) {
                 continue;

--- a/src/Exception/ParseError.php
+++ b/src/Exception/ParseError.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/classy
+ */
+
+namespace Localheinz\Classy\Exception;
+
+final class ParseError extends \ParseError implements ExceptionInterface
+{
+    public static function fromParseError(\ParseError $exception): self
+    {
+        return new self(
+            $exception->getMessage(),
+            0,
+            $exception
+        );
+    }
+
+    public static function fromFileNameAndParseError(string $fileName, \ParseError $exception): self
+    {
+        return new self(
+            \sprintf(
+                'A parse error occurred when parsing "%s": "%s".',
+                $fileName,
+                $exception->getMessage()
+            ),
+            0,
+            $exception
+        );
+    }
+}

--- a/test/Unit/ConstructsTest.php
+++ b/test/Unit/ConstructsTest.php
@@ -22,6 +22,30 @@ use PHPUnit\Framework;
 final class ConstructsTest extends Framework\TestCase
 {
     /**
+     * @var string
+     */
+    private $fileWithParseError = __DIR__ . '/../Fixture/ParseError/MessedUp.php';
+
+    protected function setUp()
+    {
+        \file_put_contents($this->fileWithParseError, $this->sourceTriggeringParseError());
+    }
+
+    protected function tearDown()
+    {
+        \unlink($this->fileWithParseError);
+    }
+
+    public function testFromSourceThrowsParseErrorIfParseErrorIsThrownDuringParsing()
+    {
+        $source = $this->sourceTriggeringParseError();
+
+        $this->expectException(Exception\ParseError::class);
+
+        Constructs::fromSource($source);
+    }
+
+    /**
      * @dataProvider providerSourceWithoutClassyConstructs
      *
      * @param string $source
@@ -70,6 +94,15 @@ final class ConstructsTest extends Framework\TestCase
         $directory = __DIR__ . '/NonExistent';
 
         $this->expectException(Exception\DirectoryDoesNotExist::class);
+
+        Constructs::fromDirectory($directory);
+    }
+
+    public function testFromDirectoryThrowsParseErrorIfParseErrorIsThrownDuringParsing()
+    {
+        $directory = __DIR__ . '/../Fixture/ParseError';
+
+        $this->expectException(Exception\ParseError::class);
 
         Constructs::fromDirectory($directory);
     }
@@ -255,5 +288,15 @@ final class ConstructsTest extends Framework\TestCase
                 ],
             ],
         ];
+    }
+
+    private function sourceTriggeringParseError(): string
+    {
+        return <<<'TXT'
+<?php
+
+final class MessedUp
+{
+TXT;
     }
 }

--- a/test/Unit/Exception/AbstractTestCase.php
+++ b/test/Unit/Exception/AbstractTestCase.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/classy
+ */
+
+namespace Localheinz\Classy\Test\Unit\Exception;
+
+use Localheinz\Classy\Exception\ExceptionInterface;
+use Localheinz\Test\Util\Helper;
+use PHPUnit\Framework;
+
+abstract class AbstractTestCase extends Framework\TestCase
+{
+    use Helper;
+
+    final public function testImplementsExceptionInterface()
+    {
+        $this->assertClassImplementsInterface(ExceptionInterface::class, $this->className());
+    }
+
+    final protected function className(): string
+    {
+        return \preg_replace(
+            '/Test$/',
+            '',
+            \str_replace(
+                'Localheinz\\Classy\\Test\\Unit\\',
+                'Localheinz\\Classy\\',
+                static::class
+            )
+        );
+    }
+}

--- a/test/Unit/Exception/DirectoryDoesNotExistTest.php
+++ b/test/Unit/Exception/DirectoryDoesNotExistTest.php
@@ -14,19 +14,9 @@ declare(strict_types=1);
 namespace Localheinz\Classy\Test\Unit\Exception;
 
 use Localheinz\Classy\Exception\DirectoryDoesNotExist;
-use Localheinz\Classy\Exception\ExceptionInterface;
-use Localheinz\Test\Util\Helper;
-use PHPUnit\Framework;
 
-final class DirectoryDoesNotExistTest extends Framework\TestCase
+final class DirectoryDoesNotExistTest extends AbstractTestCase
 {
-    use Helper;
-
-    public function testImplementsExceptionInterface()
-    {
-        $this->assertClassImplementsInterface(ExceptionInterface::class, DirectoryDoesNotExist::class);
-    }
-
     public function testFromDirectoryReturnsException()
     {
         $directory = $this->faker()->sentence;

--- a/test/Unit/Exception/MultipleDefinitionsFoundTest.php
+++ b/test/Unit/Exception/MultipleDefinitionsFoundTest.php
@@ -14,20 +14,10 @@ declare(strict_types=1);
 namespace Localheinz\Classy\Test\Unit\Exception;
 
 use Localheinz\Classy\Construct;
-use Localheinz\Classy\Exception\ExceptionInterface;
 use Localheinz\Classy\Exception\MultipleDefinitionsFound;
-use Localheinz\Test\Util\Helper;
-use PHPUnit\Framework;
 
-final class MultipleDefinitionsFoundTest extends Framework\TestCase
+final class MultipleDefinitionsFoundTest extends AbstractTestCase
 {
-    use Helper;
-
-    public function testImplementsExceptionInterface()
-    {
-        $this->assertClassImplementsInterface(ExceptionInterface::class, MultipleDefinitionsFound::class);
-    }
-
     public function testFromConstructsReturnsException()
     {
         $name = 'Foo\\Bar\\Baz';

--- a/test/Unit/Exception/ParseErrorTest.php
+++ b/test/Unit/Exception/ParseErrorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/classy
+ */
+
+namespace Localheinz\Classy\Test\Unit\Exception;
+
+use Localheinz\Classy\Exception\ParseError;
+
+final class ParseErrorTest extends AbstractTestCase
+{
+    public function testExtendsParseError()
+    {
+        $this->assertClassExtends(\ParseError::class, ParseError::class);
+    }
+
+    public function testFromParseErrorReturnsException()
+    {
+        $parseError = new \ParseError($this->faker()->sentence());
+
+        $exception = ParseError::fromParseError($parseError);
+
+        $this->assertInstanceOf(ParseError::class, $exception);
+        $this->assertSame($parseError->getMessage(), $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertSame($parseError, $exception->getPrevious());
+    }
+
+    public function testFromFileNameAndParseErrorReturnsException()
+    {
+        $fileName = __FILE__;
+        $parseError = new \ParseError($this->faker()->sentence());
+
+        $exception = ParseError::fromFileNameAndParseError(
+            $fileName,
+            $parseError
+        );
+
+        $this->assertInstanceOf(ParseError::class, $exception);
+
+        $expectedMessage = \sprintf(
+            'A parse error occurred when parsing "%s": "%s".',
+            $fileName,
+            $parseError->getMessage()
+        );
+
+        $this->assertSame($expectedMessage, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertSame($parseError, $exception->getPrevious());
+    }
+}


### PR DESCRIPTION
This PR

* [x] catches `ParseError`s and throws them again