### PR TITLE
Fix: Explicitly list infection stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
 stages:
   - style
   - test
+  - infection
 
 jobs:
   include:


### PR DESCRIPTION
This PR

* [x] explicitly lists the `infection` stage in `.travis.yml`