### PR TITLE
Enhancement: Require phpstan/phpstan-strict-rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "localheinz/test-util": "0.2.2",
     "phpbench/phpbench": "~0.14.0",
     "phpstan/phpstan": "~0.10.5",
+    "phpstan/phpstan-strict-rules": "~0.10.1",
     "phpunit/phpunit": "^7.4.4"
   },
   "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0deb1421e5f4d5099ec8951d1546a02",
+    "content-hash": "b03e6240a2287bd71bc12369b702e234",
     "packages": [],
     "packages-dev": [
         {
@@ -2412,6 +2412,52 @@
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "time": "2018-10-20T17:24:55+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-strict-rules",
+            "version": "0.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-strict-rules.git",
+                "reference": "18c0b6e8899606b127c680402ab473a7b67166db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/18c0b6e8899606b127c680402ab473a7b67166db",
+                "reference": "18c0b6e8899606b127c680402ab473a7b67166db",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.0",
+                "php": "~7.1",
+                "phpstan/phpstan": "^0.10"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.0.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "jakub-onderka/php-parallel-lint": "^1.0",
+                "phing/phing": "^2.16.0",
+                "phpstan/phpstan-phpunit": "^0.10",
+                "phpunit/phpunit": "^7.0",
+                "slevomat/coding-standard": "^4.5.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Extra strict and opinionated rules for PHPStan",
+            "time": "2018-07-06T20:36:44+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,5 @@
+includes:
+	- vendor/phpstan/phpstan-strict-rules/rules.neon
+
 parameters:
 	tmpDir: %rootDir%/.phpstan


### PR DESCRIPTION
This PR

* [x] requires `phpstan/phpstan-strict-rules` 
* [x] includes `rules.neon` from `phpstan/phpstan-strict-rules` 