### PR TITLE
Enhancement: Require localheinz/phpstan-rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
   "require-dev": {
     "infection/infection": "~0.11.2",
     "localheinz/php-cs-fixer-config": "~1.16.1",
+    "localheinz/phpstan-rules": "~0.3.0",
     "localheinz/test-util": "0.2.2",
     "phpbench/phpbench": "~0.14.0",
     "phpstan/phpstan": "~0.10.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b03e6240a2287bd71bc12369b702e234",
+    "content-hash": "e14a2b50836ff9bca38ce85adceca39f",
     "packages": [],
     "packages-dev": [
         {
@@ -788,6 +788,58 @@
             "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
             "homepage": "https://github.com/localheinz/php-cs-fixer-config",
             "time": "2018-11-20T22:00:43+00:00"
+        },
+        {
+            "name": "localheinz/phpstan-rules",
+            "version": "0.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/localheinz/phpstan-rules.git",
+                "reference": "e73d0627cc05d2606d8dba6b05b9df184cc6ad1e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/localheinz/phpstan-rules/zipball/e73d0627cc05d2606d8dba6b05b9df184cc6ad1e",
+                "reference": "e73d0627cc05d2606d8dba6b05b9df184cc6ad1e",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.1.0",
+                "php": "^7.1",
+                "phpstan/phpstan": "~0.10.5"
+            },
+            "require-dev": {
+                "infection/infection": "~0.11.1",
+                "localheinz/composer-normalize": "^1.0.0",
+                "localheinz/php-cs-fixer-config": "~1.16.1",
+                "localheinz/test-util": "~0.7.0",
+                "phpstan/phpstan-strict-rules": "~0.10.1",
+                "phpunit/phpunit": "^7.4.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Localheinz\\PHPStan\\Rules\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides additional rules for phpstan/phpstan.",
+            "homepage": "https://github.com/localheinz/phpstan-rules",
+            "keywords": [
+                "PHPStan",
+                "phpstan-extreme-rules",
+                "phpstan-rules"
+            ],
+            "time": "2018-11-25T10:14:39+00:00"
         },
         {
             "name": "localheinz/test-util",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 includes:
+	- vendor/localheinz/phpstan-rules/rules.neon
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
 
 parameters:

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -23,11 +23,6 @@ final class SrcCodeTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testSrcClassesAreAbstractOrFinal(): void
-    {
-        $this->assertClassesAreAbstractOrFinal(__DIR__ . '/../../src');
-    }
-
     public function testSrcClassesHaveTests(): void
     {
         $this->assertClassesHaveTests(


### PR DESCRIPTION
This PR

* [x] requires `localheinz/phpstan-rules`
* [x] includes `rules.neon` from `localheinz/phpstan-rules`
* [x] removes auto-review tests asserting that source classes are `abstract` or `final`