### PR TITLE
Fix: Use currentWorkingDirectory instead of rootDir for phpstan configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpstan/
 /vendor/
 /.php_cs.cache
 /infection-log.txt

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,4 +7,4 @@ parameters:
 		- %currentWorkingDirectory%/test/Fixture
 	ignoreErrors:
 		- '#Parameter \#1 ...\$fileNames of method Localheinz\\Classy\\Construct::definedIn\(\) expects string, string\|false given.#'
-	tmpDir: %rootDir%/.phpstan
+	tmpDir: %currentWorkingDirectory%/.phpstan


### PR DESCRIPTION
This PR

* [x] uses `%currentWorkingDirectory%` instead of `%rootDir%` for `phpstan` configuration