### PR TITLE
Enhancement: Require phpstan/phpstan-deprecation-rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "localheinz/test-util": "0.2.2",
     "phpbench/phpbench": "~0.15.0",
     "phpstan/phpstan": "~0.10.7",
+    "phpstan/phpstan-deprecation-rules": "~0.10.2",
     "phpstan/phpstan-strict-rules": "~0.10.1",
     "phpunit/phpunit": "^7.5.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b9e3f3a509a42e6758b12f4d14953c9",
+    "content-hash": "b81ad63df53bb7643dc6640d35b2a407",
     "packages": [],
     "packages-dev": [
         {
@@ -2836,6 +2836,52 @@
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "time": "2018-12-28T13:47:37+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-deprecation-rules",
+            "version": "0.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
+                "reference": "fc7d373a760d2bf5cf999b052072adfa728892a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/fc7d373a760d2bf5cf999b052072adfa728892a0",
+                "reference": "fc7d373a760d2bf5cf999b052072adfa728892a0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.0",
+                "php": "~7.1",
+                "phpstan/phpstan": "^0.10"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.0.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "jakub-onderka/php-parallel-lint": "^1.0",
+                "phing/phing": "^2.16.0",
+                "phpstan/phpstan-phpunit": "^0.10",
+                "phpunit/phpunit": "^7.0",
+                "slevomat/coding-standard": "^4.5.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "time": "2018-06-30T14:42:51+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
 	- vendor/localheinz/phpstan-rules/rules.neon
+	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
 	- vendor/phpstan/phpstan/conf/config.levelmax.neon
 

--- a/test/Unit/ConstructTest.php
+++ b/test/Unit/ConstructTest.php
@@ -38,7 +38,7 @@ final class ConstructTest extends Framework\TestCase
     {
         $construct = Construct::fromName($this->faker()->word);
 
-        self::assertInternalType('array', $construct->fileNames());
+        self::assertIsArray($construct->fileNames());
         self::assertCount(0, $construct->fileNames());
     }
 
@@ -72,7 +72,7 @@ final class ConstructTest extends Framework\TestCase
         self::assertInstanceOf(Construct::class, $mutated);
         self::assertNotSame($construct, $mutated);
         self::assertSame($name, $mutated->name());
-        self::assertInternalType('array', $mutated->fileNames());
+        self::assertIsArray($mutated->fileNames());
         self::assertCount(\count($fileNames), $mutated->fileNames());
         self::assertArraySubset($fileNames, $mutated->fileNames());
     }


### PR DESCRIPTION
This PR

* [x] requires `phpstan/phpstan-deprecation-rules`
* [x] includes `rules.neon` from `phpstan/phpstan-deprecation-rules`
* [x] uses alternatives to deprecated assertions